### PR TITLE
Styled Crop & Meal Cards

### DIFF
--- a/mealsfromdirt/src/components/CropCard.js
+++ b/mealsfromdirt/src/components/CropCard.js
@@ -14,7 +14,7 @@ import Link from '@mui/material/Link';
 function CropCard(props){
 
     const {cropName, cropImgURL, cropDesc, cropPlantMonth, cropHarvestMonth} = props;
-    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov',' Dec'];
+    const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November',' December'];
 
     const [open, setOpen] = useState(false);
 

--- a/mealsfromdirt/src/components/CropCard.js
+++ b/mealsfromdirt/src/components/CropCard.js
@@ -9,9 +9,10 @@ import DialogTitle from "@mui/material/DialogTitle";
 import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
 import Stack from '@mui/material/Stack';
+import Link from '@mui/material/Link';
 
 function CropCard(props){
-    const {cropName, cropImgURL, cropDesc, cropResources} = props;
+    const {cropName, cropImgURL, cropDesc} = props;
 
     const [open, setOpen] = useState(false);
 
@@ -24,10 +25,10 @@ function CropCard(props){
 
     return(
         <Fragment>
-            <Card sx={{  width:200, height:200, m: 2 }}>
+            <Card sx={{  width: 250, m: 2 }}>
                 <CardActionArea onClick={handleCardOpen}>
                     <CardContent>
-                        <Typography gutterBottom variant="h6" component="div">
+                        <Typography gutterBottom variant="h6" component="div"  fontWeight="bold">
                             {cropName}
                         </Typography>
                     </CardContent>
@@ -44,13 +45,20 @@ function CropCard(props){
                     open={open}
                     onClose={handleCardClose}
                 >
-                    <DialogTitle>Crop Card Content</DialogTitle>
-                    <DialogContent>
-                        <DialogContentText>
-                            Description: {cropDesc}
+                    <DialogTitle fontWeight="bold">{cropName}</DialogTitle>
+                    <DialogContent dividers>
+                        <DialogContentText fontWeight="bold">
+                            Description:
+                            <Typography variant="body2" color="text.secondary">
+                                {cropDesc}
+                            </Typography>
                         </DialogContentText>
-                        <DialogContentText>
-                            Resources: {cropResources}
+                        <DialogContentText fontWeight="bold">
+                            Resources / Other Useful Information: 
+                            <Typography variant="body2" color="text.secondary">
+                                Follow this link to research more on this crop:
+                                <Link>https://plants.usda.gov/home</Link>
+                            </Typography>
                         </DialogContentText>
                     </DialogContent>
                 </Dialog>

--- a/mealsfromdirt/src/components/CropCard.js
+++ b/mealsfromdirt/src/components/CropCard.js
@@ -13,7 +13,7 @@ import Link from '@mui/material/Link';
 
 function CropCard(props){
 
-    const {cropName, cropImgURL, cropDesc, cropPlantMonth, cropHarvestMonth} = props;
+    const {cropName, cropImgURL, cropDesc, cropResources, cropPlantMonth, cropHarvestMonth} = props;
     const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November',' December'];
 
     const [open, setOpen] = useState(false);
@@ -72,8 +72,7 @@ function CropCard(props){
                         <DialogContentText fontWeight="bold">
                             Resources / Other Useful Information: 
                             <Typography variant="body2" color="text.secondary">
-                                Follow this link to research more on this crop:
-                                <Link>https://plants.usda.gov/home</Link>
+                                {cropResources}
                             </Typography>
                         </DialogContentText>
                     </DialogContent>

--- a/mealsfromdirt/src/components/MealCard.js
+++ b/mealsfromdirt/src/components/MealCard.js
@@ -26,10 +26,10 @@ function MealCard(props) {
 
     return (
     <Fragment>
-        <Card sx={{  width:200, height:300, m: 2 }}>
+        <Card sx={{  width: 300, m: 2, justifyContent: 'center'}}>
             <CardActionArea onClick={handleCardOpen}>
                 <CardContent>
-                    <Typography gutterBottom variant="h6" component="div">
+                    <Typography gutterBottom variant="h7" component="div" fontWeight="bold">
                         {recipe_name}
                     </Typography>
                 </CardContent>
@@ -45,12 +45,18 @@ function MealCard(props) {
             <Dialog open={open}
                     onClose={handleCardClose}>
                     <DialogTitle>{recipe_name}</DialogTitle>
-                    <DialogContent>
-                        <DialogContentText>
-                            Description: {recipe_description}
+                    <DialogContent dividers>
+                        <DialogContentText fontWeight="bold">
+                            Description: 
+                            <Typography variant="body2" color="text.secondary">
+                                {recipe_description}
+                            </Typography>
                         </DialogContentText>
-                        <DialogContentText>
-                            Instructions: {recipe_instructions}
+                        <DialogContentText fontWeight="bold">
+                            Instructions: 
+                            <Typography variant="body2" color="text.secondary">
+                                {recipe_instructions}
+                            </Typography>
                         </DialogContentText>
                     </DialogContent>
             </Dialog>


### PR DESCRIPTION
Organized pop-up content to be cleaner.
Replaced resources to have a link to USDA as a place holder rather than "Sample Resources". Bolded headers and adjusted card sizes. Crop and Meal cards are now organized in the center of the container rather than on the left side of the inside of the container.